### PR TITLE
Fix trigger buttons scaling issue + module selection issue

### DIFF
--- a/Assets/Components/Base L1.obj.meta
+++ b/Assets/Components/Base L1.obj.meta
@@ -41,7 +41,7 @@ ModelImporter:
     isReadable: 1
   meshes:
     lODScreenPercentages: []
-    globalScale: 1
+    globalScale: 0.1
     meshCompression: 0
     addColliders: 0
     importVisibility: 1

--- a/Assets/Components/Base L2.obj.meta
+++ b/Assets/Components/Base L2.obj.meta
@@ -41,7 +41,7 @@ ModelImporter:
     isReadable: 1
   meshes:
     lODScreenPercentages: []
-    globalScale: 1
+    globalScale: 0.1
     meshCompression: 0
     addColliders: 0
     importVisibility: 1

--- a/Assets/Components/Base R2.obj.meta
+++ b/Assets/Components/Base R2.obj.meta
@@ -41,7 +41,7 @@ ModelImporter:
     isReadable: 1
   meshes:
     lODScreenPercentages: []
-    globalScale: 1
+    globalScale: 0.1
     meshCompression: 0
     addColliders: 0
     importVisibility: 1

--- a/Assets/Components/L1.obj.meta
+++ b/Assets/Components/L1.obj.meta
@@ -41,7 +41,7 @@ ModelImporter:
     isReadable: 1
   meshes:
     lODScreenPercentages: []
-    globalScale: 1
+    globalScale: 0.1
     meshCompression: 0
     addColliders: 0
     importVisibility: 1

--- a/Assets/Components/L2.obj.meta
+++ b/Assets/Components/L2.obj.meta
@@ -41,7 +41,7 @@ ModelImporter:
     isReadable: 1
   meshes:
     lODScreenPercentages: []
-    globalScale: 1
+    globalScale: 0.1
     meshCompression: 0
     addColliders: 0
     importVisibility: 1

--- a/Assets/Components/R1.obj.meta
+++ b/Assets/Components/R1.obj.meta
@@ -41,7 +41,7 @@ ModelImporter:
     isReadable: 1
   meshes:
     lODScreenPercentages: []
-    globalScale: 1
+    globalScale: 0.1
     meshCompression: 0
     addColliders: 0
     importVisibility: 1

--- a/Assets/Components/R2.obj.meta
+++ b/Assets/Components/R2.obj.meta
@@ -41,7 +41,7 @@ ModelImporter:
     isReadable: 1
   meshes:
     lODScreenPercentages: []
-    globalScale: 1
+    globalScale: 0.1
     meshCompression: 0
     addColliders: 0
     importVisibility: 1

--- a/Assets/GTACheats.unity
+++ b/Assets/GTACheats.unity
@@ -152,22 +152,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 4636827926110272, guid: 4882b38d15a3d4646a77fea90659de83, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4636827926110272, guid: 4882b38d15a3d4646a77fea90659de83, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4636827926110272, guid: 4882b38d15a3d4646a77fea90659de83, type: 2}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4636827926110272, guid: 4882b38d15a3d4646a77fea90659de83, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 4882b38d15a3d4646a77fea90659de83, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/GTAModule.prefab
+++ b/Assets/GTAModule.prefab
@@ -3854,7 +3854,7 @@ MonoBehaviour:
   - {fileID: 114351211046038092}
   - {fileID: 114890397824965274}
   - {fileID: 114073548763461310}
-  IsPassThrough: 1
+  IsPassThrough: 0
   ChildRowLength: 0
   Highlight: {fileID: 114162695745716814}
   SelectableColliders: []

--- a/Assets/GTAModule.prefab
+++ b/Assets/GTAModule.prefab
@@ -1250,7 +1250,7 @@ Transform:
   m_GameObject: {fileID: 1417009492771106}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4686877455795540}
   m_RootOrder: 1
@@ -1310,7 +1310,7 @@ Transform:
   m_GameObject: {fileID: 1908063785135694}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4235006004826858}
   m_RootOrder: 0
@@ -1642,7 +1642,7 @@ Transform:
   m_GameObject: {fileID: 1507496934457074}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4906198805702984}
   m_RootOrder: 0
@@ -1726,7 +1726,7 @@ Transform:
   m_GameObject: {fileID: 1654204553923358}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4022359587969570}
   m_RootOrder: 1
@@ -1753,7 +1753,7 @@ Transform:
   m_GameObject: {fileID: 1365587332545568}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4737540165202384}
   m_RootOrder: 0
@@ -1779,7 +1779,7 @@ Transform:
   m_GameObject: {fileID: 1689631145055694}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4005255837359130}
   m_RootOrder: 0
@@ -1821,9 +1821,9 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1015036914164664}
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 100, y: 100, z: 100}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4405108932748500}
   - {fileID: 4309969162129244}
@@ -1831,7 +1831,7 @@ Transform:
   - {fileID: 4081588358221300}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4654180602088954
 Transform:
   m_ObjectHideFlags: 1
@@ -1910,7 +1910,7 @@ Transform:
   m_GameObject: {fileID: 1083682170552312}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4511579508267774}
   m_RootOrder: 0
@@ -2059,7 +2059,7 @@ Transform:
   m_GameObject: {fileID: 1806860793290078}
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 4271443396475578}
   m_RootOrder: 1
@@ -4018,6 +4018,7 @@ MonoBehaviour:
   Cheats: {fileID: 114593221487247456}
   input_code: []
   value: 0
+  reason: 
 --- !u!114 &114485860752204954
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
The scale of the trigger buttons on the prefab are very small. Due to this, when the module is scaled to fit on a bomb it shrinks them even more causing them to lose their texture and become purely black. This fixes the issue by scaling the trigger buttons models on the prefab by 10, and decreasing the scale back to fit with the import scale of each model instead.

Also there was a selectable issue with the module caused by a checkbox being ticked that didn't need to be. That is fixed in this as well.